### PR TITLE
JBDS-3292 Update release notes link to 8.0.1 on updates/8.0* index pages

### DIFF
--- a/content/updates/8.0-development/index.html
+++ b/content/updates/8.0-development/index.html
@@ -96,7 +96,7 @@
 <hr size="1"/>
 
   <h4 style="padding-bottom:10px">News:</h4> 
-  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html">Release Notes</a><br/>
+  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.1_Release_Notes/index.html">Release Notes</a><br/>
   <a style="color:blue" href="http://tools.jboss.org/blog/2014-10-22-GA-for-luna.html">Release Announcement</a><br/><br/>
 
   <h4 style="padding-bottom:10px">Getting Started:</h4> 

--- a/content/updates/8.0-staging/index.html
+++ b/content/updates/8.0-staging/index.html
@@ -96,7 +96,7 @@
 <hr size="1"/>
 
   <h4 style="padding-bottom:10px">News:</h4> 
-  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html">Release Notes</a><br/>
+  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.1_Release_Notes/index.html">Release Notes</a><br/>
   <a style="color:blue" href="http://tools.jboss.org/blog/2014-10-22-GA-for-luna.html">Release Announcement</a><br/><br/>
 
   <h4 style="padding-bottom:10px">Getting Started:</h4> 

--- a/content/updates/8.0/index.html
+++ b/content/updates/8.0/index.html
@@ -96,7 +96,7 @@
 <hr size="1"/>
 
   <h4 style="padding-bottom:10px">News:</h4> 
-  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html">Release Notes</a><br/>
+  <a onClick="javascript: _gaq.push(['_trackPageview', cleanURL(this.href, 'access.redhat.com/')])" href="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.1_Release_Notes/index.html">Release Notes</a><br/>
   <a style="color:blue" href="http://tools.jboss.org/blog/2014-10-22-GA-for-luna.html">Release Announcement</a><br/><br/>
 
   <h4 style="padding-bottom:10px">Getting Started:</h4> 


### PR DESCRIPTION
The html page still contained a link to 8.0.0 RNs. Updated to 8.0.1.
